### PR TITLE
chore(build) temporary remove travis EE builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ jobs:
     env: KONG_VERSION=2.0.x
   - name: Kong CE 1.5.x
     env: KONG_VERSION=1.5.x
-  - name: Enterprise 1.5.0.x
-    env: KONG_VERSION=1.5.0.x
-  - name: Nightly EE-master
-    env: KONG_VERSION=nightly-ee POSTGRES=latest CASSANDRA=latest
+  #- name: Enterprise 1.5.0.x
+  #  env: KONG_VERSION=1.5.0.x
+  #- name: Nightly EE-master
+  #  env: KONG_VERSION=nightly-ee POSTGRES=latest CASSANDRA=latest
   #- name: Nightly CE-master
   #  env: KONG_VERSION=nightly POSTGRES=latest CASSANDRA=latest
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+[![Build Status][badge-travis-image]][badge-travis-url]
 
 Kong header router plugin
 =========================
 
 Simple Kong plugin which overrides default service upstream if specific headers are set.
+
+[badge-travis-url]: https://travis-ci.com/dgorniak/kong-header-router/branches
+[badge-travis-image]: https://travis-ci.com/dgorniak/kong-header-router.svg?branch=master
 


### PR DESCRIPTION
This PR temporarly removes Kong EE builds form travis.yml and
restores travis badges in README.md